### PR TITLE
add styling for aboutUs navbar and added styling for active link on mainNavbar

### DIFF
--- a/components/layout/AboutUsNavigation.js
+++ b/components/layout/AboutUsNavigation.js
@@ -1,13 +1,34 @@
 import classes from "./AboutUsNavigation.module.css";
+import Link from "next/link";
+import { useRouter } from "next/router";
 
 function AboutUsNavigation() {
+
+    const router = useRouter();
+
     return (
         <nav className={classes.aboutUsNav}>
             <ul className={classes.aboutUsMenu}>
-                <li><a className={classes.menuText} href="/aboutus/history">Historia</a></li>
-                <li><a className={classes.menuText} href="/aboutus/policy">Policy</a></li>
-                <li><a className={classes.menuText} href="/aboutus/accessibility">Tillgänglighet</a></li >
-                <li><a className={classes.menuText} href="/aboutus/faq">FAQ</a></li >
+                <li>
+                    <Link href="/aboutus/history">
+                        <a className={router.pathname == "/aboutus/history" ? `${classes.active} ${classes.menuText}` : `${classes.menuText}`}>Historia</a>
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/aboutus/policy">
+                        <a className={router.pathname == "/aboutus/policy" ? `${classes.active} ${classes.menuText}` : `${classes.menuText}`}>Policy</a>
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/aboutus/accessibility">
+                        <a className={router.pathname == "/aboutus/accessibility" ? `${classes.active} ${classes.menuText}` : `${classes.menuText}`}>Tillgänglighet</a>
+                    </Link>
+                </li>
+                <li>
+                    <Link href="/aboutus/faq">
+                        <a className={router.pathname == "/aboutus/faq" ? `${classes.active} ${classes.menuText}` : `${classes.menuText}`}>FAQ</a>
+                    </Link>
+                </li>
             </ul >
         </nav >
     )

--- a/components/layout/AboutUsNavigation.module.css
+++ b/components/layout/AboutUsNavigation.module.css
@@ -1,25 +1,19 @@
 .aboutUsNav {
-    width: 100%;
-    height: 4rem;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    background-color: #77002e;
-    position: absolute;
-    left: 0;
-    top: 7rem;
+    border-bottom: 3px solid red;
+    height: 3.5rem;
+    margin: auto;
+    width: 80%;
 }
 
 .aboutUsMenu {
     align-items: center;
     display: flex;
     flex-direction: row;
-    height: 40px;
+    height: 3.5rem;
     justify-content: space-between;
     padding: 0;
     margin: auto;
     width: 60%;
-
     list-style-type: none;
 }
 
@@ -36,4 +30,6 @@
     color: goldenrod;
 }                    
 
-       
+.active {
+    color: goldenrod;
+}     

--- a/components/layout/MainNavigation.js
+++ b/components/layout/MainNavigation.js
@@ -1,30 +1,42 @@
 import classes from './MainNavigation.module.css';
-import Link from "next/link";
+import Link from 'next/link';
+import { useRouter } from 'next/dist/client/router';
 
 function MainNavigation() {
 
+    const router = useRouter();
+
     return (
         <header className={classes.header}>
-            <a
-                className={classes.logo}
-                href='/'>
-            </a>
+            <Link href='/'>
+                <a className={classes.logo} />
+            </Link>
             <nav>
                 <ul>
                     <li>
-                        <Link href='/movies'>Filmer</Link>
+                        <Link href='/movies'>
+                            <a className={router.pathname == '/movies' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Filmer</a>
+                        </Link>
                     </li>
                     <li>
-                        <Link href='/tickets'>Biljetter</Link>
+                        <Link href='/tickets'>
+                            <a className={router.pathname == '/tickets' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Biljetter</a>
+                        </Link>
                     </li>
                     <li>
-                        <Link href='/aboutus'>Om oss</Link>
+                        <Link href='/aboutus/history'>
+                            <a className={router.pathname == '/aboutus/history' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Om oss</a>
+                        </Link>
                     </li>
                     <li>
-                        <Link href='/contact'>Kontakt</Link>
+                        <Link href='/contact'>
+                            <a className={router.pathname == '/contact' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Kontakt</a>
+                        </Link>
                     </li>
                     <li className={classes.login}>
-                        <Link href='/login'>Logga in</Link>
+                        <Link href='/login'>
+                            <a className={router.pathname == '/login' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Logga in</a>
+                        </Link>
                     </li>
                 </ul>
             </nav>

--- a/components/layout/MainNavigation.js
+++ b/components/layout/MainNavigation.js
@@ -1,6 +1,6 @@
 import classes from './MainNavigation.module.css';
 import Link from 'next/link';
-import { useRouter } from 'next/dist/client/router';
+import { useRouter } from 'next/router';
 
 function MainNavigation() {
 

--- a/components/layout/MainNavigation.js
+++ b/components/layout/MainNavigation.js
@@ -25,12 +25,12 @@ function MainNavigation() {
                     </li>
                     <li>
                         <Link href='/aboutus/history'>
-                            <a className={router.pathname == '/aboutus/history' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Om oss</a>
+                            <a className={router.pathname.slice(0, 8) == '/aboutus' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Om oss</a>
                         </Link>
                     </li>
                     <li>
                         <Link href='/contact'>
-                            <a className={router.pathname == '/contact' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Kontakt</a>
+                            <a className={router.pathname.slice(0, 8) == '/contact' ? `${classes.active} ${classes.mainMenuText}` : `${classes.mainMenuText}`}>Kontakt</a>
                         </Link>
                     </li>
                     <li className={classes.login}>

--- a/components/layout/MainNavigation.module.css
+++ b/components/layout/MainNavigation.module.css
@@ -31,19 +31,18 @@
     margin-left: 3rem;
   }
   
-  .header a {
+  .mainMenuText {
     text-decoration: none;
     font-size: 1.5rem;
-    color: rgba(255, 255, 255, 0.8);
+    color: rgba(255, 255, 255, 0.582);
   }
   
-  .header a:hover,
-  .header a:active,
-  .header a.active {
+  .mainMenuText:hover,
+  .mainMenuText.active {
     color: #fff;
   }
-  
-  .login {
+
+    .login {
     position: absolute;
     right: 2rem;
   }


### PR DESCRIPTION
Fix navbar on aboutUs with styling, plus small change for active links in styling for mainNavbar.
(also change pathname in link for /aboutus to /aboutus/history in mainNav, so that aboutus/history is active when you enter aboutus)

Maybe there should be a slightly bigger difference in color on mainNav for active/inactive link?  

![image](https://user-images.githubusercontent.com/89969770/166094261-ed0f2bd5-a79c-4dde-a3e9-022475fd5c47.png)
