### PR TITLE
Revalidate fix

### DIFF
--- a/pages/api/review.js
+++ b/pages/api/review.js
@@ -1,10 +1,20 @@
 import { postReview } from "../../helpers/reviewHelper";
 
 export default async function handler(req, res) {
-    if(req.method === "POST") {
+    if (req.method === "POST") {
         const data = req.body;
-        const result = postReview(data);
+        const movieId = req.body.movieId;
+        await postReview(data);
+        try {
+            await res.unstable_revalidate(`/movies/${movieId}`);
 
-        res.status(201).json({ message: "Review posted"})
+            return res.json({ revalidated: true })
+        } catch (err) {
+            // If there was an error, Next.js will continue
+            // to show the last successfully generated page
+            return res.status(500).send('Error revalidating')
+        }
+    } else {
+        return res.status(405)
     }
 }

--- a/pages/movies/[movieID]/index.js
+++ b/pages/movies/[movieID]/index.js
@@ -119,7 +119,7 @@ export async function getStaticPaths() {
     const posters = await pathHelper();
 
     return {
-        fallback: false,
+        fallback: "blocking",
         paths: posters.map(poster => ({
             params: { movieID: poster._id.toString() }
         })),
@@ -147,8 +147,8 @@ export async function getStaticProps(context) {
                 comment: review.comment,
             })),
             movieId: movieID,
-        }, revalidate: 5,
-    }
+        }, revalidate: 1,
+    };
 }
 
 export default SpecificMovie; 

--- a/pages/movies/[movieID]/index.js
+++ b/pages/movies/[movieID]/index.js
@@ -115,7 +115,7 @@ export async function getStaticPaths() {
     const posters = await pathHelper();
 
     return {
-        fallback: "false",
+        fallback: false,
         paths: posters.map(poster => ({
             params: { movieID: poster._id.toString() }
         })),

--- a/pages/movies/[movieID]/index.js
+++ b/pages/movies/[movieID]/index.js
@@ -115,7 +115,7 @@ export async function getStaticPaths() {
     const posters = await pathHelper();
 
     return {
-        fallback: "blocking",
+        fallback: "false",
         paths: posters.map(poster => ({
             params: { movieID: poster._id.toString() }
         })),

--- a/pages/movies/[movieID]/index.js
+++ b/pages/movies/[movieID]/index.js
@@ -11,7 +11,7 @@ import React, { useContext } from "react";
 import { Context } from "../../_app";
 
 
-function SpecifcMovie(props) {
+function SpecificMovie(props) {
     const [rating, setRating] = useState(1);
     const [review, setReview] = useState("");
     const [name, setName] = useState("");
@@ -147,8 +147,8 @@ export async function getStaticProps(context) {
                 comment: review.comment,
             })),
             movieId: movieID,
-        }
+        }, revalidate: 5,
     }
 }
 
-export default SpecifcMovie; 
+export default SpecificMovie; 

--- a/pages/movies/[movieID]/index.js
+++ b/pages/movies/[movieID]/index.js
@@ -3,7 +3,6 @@ import ReviewList from "../../../components/reviews/reviewList";
 import { getReviews } from "../../../helpers/reviewHelper";
 import ReviewForm from "../../../components/reviews/ReviewForm";
 import { useState } from "react";
-import { useRouter } from "next/router";
 import classes from "../../../styles/movieId.module.css";
 import { pathHelper, getOnePoster } from "../../../helpers/posterHelper";
 import Link from "next/link";
@@ -29,8 +28,6 @@ function SpecificMovie(props) {
         setHigh(high - 5)
     }
 
-    const router = useRouter();
-
     async function handleReview() {
         await fetch("/api/review", {
             method: "POST",
@@ -39,7 +36,7 @@ function SpecificMovie(props) {
                 rating,
                 comment: review,
                 movieId: props.movieId,
-                date: new Date()
+                date: new Date(),
             }),
             headers: {
                 "Content-Type": "application/json"
@@ -50,7 +47,6 @@ function SpecificMovie(props) {
         setRating(1);
         setLow(0)
         setHigh(5)
-        router.push("/movies/" + props.movieId);
     }
 
     return (
@@ -147,7 +143,7 @@ export async function getStaticProps(context) {
                 comment: review.comment,
             })),
             movieId: movieID,
-        }, revalidate: 1,
+        }
     };
 }
 


### PR DESCRIPTION
I noticed that we did not have a revalidate in the getStaticProps on the [movieID] index site, so i added revalidate: 1.
But the problem is that it makes nextjs regenerate all our static movie id sites and the review will still not show in our browser until we close the browser and visit it again because of how getStaticProps works with a production build. So I removed revalidate and added a new feature called unstable_revalidate and that will tell nextjs to regenerate the site with the movieId that the new review we sent in had, however it will still not show directly in the browser 

I do however think that it works better and if you visit the page in a different browser the review will show up directly. 